### PR TITLE
Add test_suite to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ if __name__ == '__main__':
           packages=packages,
           ext_modules=extensions,
           cmdclass=cmdclass,
+          test_suite='nose.collector',
           package_data={'parmed.modeller': ['data/*.lib']},
           **kws
     )


### PR DESCRIPTION
This PR integrates test runs into `setup.py`:

    python setup.py -v nosetests

This has [some advantages](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner), like to ensure that the same version of Python is used for both installation and testing.